### PR TITLE
Fix isFeatureAllowed string comparison

### DIFF
--- a/CookieBanner.php
+++ b/CookieBanner.php
@@ -29,7 +29,7 @@ class CookieBanner
         if (($cookie = self::getCookie()) === null) {
             return false;
         }
-        return str_contains($featureName, $cookie);
+        return str_contains($cookie, $featureName);
     }
 
     public static function allowedFeatures(): array


### PR DESCRIPTION
This fixes #20.
This also should fix #19.

The [`str_contains` function works vice-versa](https://www.php.net/manual/en/function.str-contains.php) than implemented before. In a local test environment this fixed the issues above and worked fine again.